### PR TITLE
Add the kip6 feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ version = "1.2.2"
 default-features = false
 
 [features]
-default = []
+default = ["kip6"]
 kip4 = []
-std = ["pwasm-std/std", "parity-hash/std", "uint/std", "byteorder/std"]
+kip6 = []
+std = ["kip6", "pwasm-std/std", "parity-hash/std", "uint/std", "byteorder/std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ version = "1.2.2"
 default-features = false
 
 [features]
-default = ["kip6"]
+default = []
 kip4 = []
 kip6 = []
-std = ["kip6", "pwasm-std/std", "parity-hash/std", "uint/std", "byteorder/std"]
+std = ["pwasm-std/std", "parity-hash/std", "uint/std", "byteorder/std"]

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -62,6 +62,7 @@ mod external {
 
 		pub fn gaslimit(dest: *mut u8);
 
+		#[cfg(feature = "kip6")]
 		pub fn gasleft() -> i64;
 
 		pub fn sender(dest: *mut u8);
@@ -255,6 +256,7 @@ pub fn gas_limit() -> U256 {
 	unsafe { fetch_u256(|x| external::gaslimit(x) ) }
 }
 
+#[cfg(feature = "kip6")]
 /// Get amount of gas left.
 pub fn gas_left() -> u64 {
 	unsafe { external::gasleft() as u64 }


### PR DESCRIPTION
I'd like to make `kip4` as a default as well, but don't sure